### PR TITLE
feat: Add Bookfeat: Add Book and Author repositories

### DIFF
--- a/src/main/java/com/selman/bookstore/repository/AuthorRepository.java
+++ b/src/main/java/com/selman/bookstore/repository/AuthorRepository.java
@@ -1,0 +1,9 @@
+package com.selman.bookstore.repository;
+
+import com.selman.bookstore.domain.Author;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthorRepository extends JpaRepository<Author, Long> {
+    // JpaRepository provides all basic CRUD operations (findAll, findById, save, delete, etc.)
+    // We don't need to add any custom methods here for now.
+}

--- a/src/main/java/com/selman/bookstore/repository/BookRepository.java
+++ b/src/main/java/com/selman/bookstore/repository/BookRepository.java
@@ -1,0 +1,17 @@
+package com.selman.bookstore.repository;
+
+import com.selman.bookstore.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+    /*
+     Finds a book by its unique ISBN.
+     Spring Data JPA will automatically generate the query for this method based on its name.
+     @param isbn The ISBN to search for.
+     @return An Optional containing the found book, or an empty Optional if no book is found.
+     */
+
+    Optional<Book> findByIsbn(String isbn);
+}


### PR DESCRIPTION
## Description
This PR creates the JPA repository interfaces for the `Book` and `Author` entities, providing standard CRUD functionality via Spring Data JPA.

### Changes
- Added `BookRepository` interface extending `JpaRepository`.
- Added `AuthorRepository` interface extending `JpaRepository`.
- Included a custom derived query method `findByIsbn` in `BookRepository` for efficient book lookups.

## Related Issue
Closes #2