### PR TITLE
feat: Add basic SecurityConfig for stateless JWT authentication

### DIFF
--- a/src/main/java/com/selman/bookstore/config/SecurityConfig.java
+++ b/src/main/java/com/selman/bookstore/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.selman.bookstore.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        // CSRF korumasını devre dışı bırakıyoruz (Stateless API için)
+        // Session yönetimini STATELESS olarak ayarlıyoruz
+        // HTTP istekleri için yetkilendirme kurallarını belirliyoruz
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth-> auth
+                        // /api/auth/** altındaki tüm endpoint'lere izinsiz erişime izin veriyoruz
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Description
This PR adds the initial `SecurityConfig` to the project.

### Changes
- Configured `SecurityFilterChain` to disable CSRF and use a STATELESS session policy.
- Defined authorization rules: `/api/auth/**` is public, all other requests require authentication.
- Provided a `PasswordEncoder` bean for password hashing.

## Related Issue
Closes #7