### PR TITLE
Feature/10 integrate mysql with docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: bookstore-mysql
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=bookstore_db
+      - MYSQL_USER=selman
+      - MYSQL_PASSWORD=password
+    volumes:
+      - bookstore-mysql-data:/var/lib/mysql
+
+volumes:
+  bookstore-mysql-data:

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/resources/application-dev-docker.properties
+++ b/src/main/resources/application-dev-docker.properties
@@ -1,0 +1,10 @@
+# Spring Datasource (MySQL)
+spring.datasource.url=jdbc:mysql://localhost:3306/bookstore_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+spring.datasource.username=selman
+spring.datasource.password=password
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA / Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,6 @@ logging.level.org.springframework.security=DEBUG
 
 app.jwt.secret=SelmanSaracogluSecretKeyForBookstoreApiJwtGenerationAndValidationPurposeOnly
 app.jwt.expiration-ms=3600000
+
+# Activate the dev-docker profile by default
+spring.profiles.active=dev-docker


### PR DESCRIPTION
## Description
This PR migrates the application from the in-memory H2 database to a persistent MySQL database managed by Docker Compose.

### Changes
- Added `mysql-connector-j` dependency.
- Created `docker-compose.yml` to define the MySQL service.
- Added a new Spring Profile `dev-docker` with MySQL connection properties.
- Activated the `dev-docker` profile by default.

Closes #19 