### PR TITLE
feat: Implement pagination and sorting for fetching books

### DIFF
--- a/src/main/java/com/selman/bookstore/service/BookService.java
+++ b/src/main/java/com/selman/bookstore/service/BookService.java
@@ -3,6 +3,8 @@ package com.selman.bookstore.service;
 
 import com.selman.bookstore.domain.Book;
 import com.selman.bookstore.repository.BookRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -19,8 +21,8 @@ public class BookService {
         this.bookRepository = bookRepository;
     }
 
-    public List<Book> findAllBooks() {
-        return bookRepository.findAll();
+    public Page<Book> findAllBooks(Pageable pageable) {
+        return bookRepository.findAll(pageable);
     }
 
     public Optional<Book> findBookById(Long id) {

--- a/src/main/java/com/selman/bookstore/web/rest/BookController.java
+++ b/src/main/java/com/selman/bookstore/web/rest/BookController.java
@@ -7,6 +7,8 @@ import com.selman.bookstore.mapper.BookMapper;
 import com.selman.bookstore.repository.BookRepository;
 import com.selman.bookstore.service.BookService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,12 +38,10 @@ public class BookController {
     }
 
     @GetMapping
-    public ResponseEntity<List<BookDTO>> getAllBooks() {
-        List<Book> books = bookService.findAllBooks();
-        List<BookDTO> bookDTOs = books.stream()
-                .map(bookMapper::toDTO)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(bookDTOs);
+    public ResponseEntity<Page<BookDTO>> getAllBooks(Pageable pageable) {
+        Page<Book> bookPage = bookService.findAllBooks(pageable);
+        Page<BookDTO> bookDTOPage = bookPage.map(bookMapper::toDTO);
+        return ResponseEntity.ok(bookDTOPage);
     }
 
     @GetMapping("/{id}")


### PR DESCRIPTION
## Description
This PR introduces pagination and sorting capabilities to the `GET /api/books` endpoint using Spring Data JPA's `Pageable` interface. This prevents fetching all records at once and makes the API scalable.

### Changes
- Updated `BookService` and `BookController` to handle `Pageable` requests.
- The endpoint now returns a `Page<BookDTO>` object, which includes pagination details along with the content.

## Related Issue
Closes #21 