### PR TITLE
feat: Update Service and Controller to use Specifications for filtering

### DIFF
--- a/src/main/java/com/selman/bookstore/repository/BookRepository.java
+++ b/src/main/java/com/selman/bookstore/repository/BookRepository.java
@@ -2,10 +2,11 @@ package com.selman.bookstore.repository;
 
 import com.selman.bookstore.domain.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 
-public interface BookRepository extends JpaRepository<Book, Long> {
+public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificationExecutor<Book> {
     /*
      Finds a book by its unique ISBN.
      Spring Data JPA will automatically generate the query for this method based on its name.

--- a/src/main/java/com/selman/bookstore/repository/specification/BookSpecification.java
+++ b/src/main/java/com/selman/bookstore/repository/specification/BookSpecification.java
@@ -1,0 +1,27 @@
+package com.selman.bookstore.repository.specification;
+
+import com.selman.bookstore.domain.Book;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookSpecification {
+    public Specification<Book> hasTitle(String title) {
+        return (root, query, criteriaBuilder) -> {
+            if (title == null || title.isEmpty()) {
+                return criteriaBuilder.conjunction(); // Eğer title boşsa, hiçbir filtre uygulama
+            }
+            // title alanında, büyük/küçük harf duyarsız bir şekilde arama yap
+            return criteriaBuilder.like(criteriaBuilder.lower(root.get("title")), "%" + title.toLowerCase() + "%");
+        };
+    }
+
+    public Specification<Book> hasPublicationYear(Integer year) {
+        return (root, query, criteriaBuilder) -> {
+            if (year == null) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.equal(root.get("publicationTear"), year);
+        };
+    }
+}

--- a/src/main/java/com/selman/bookstore/service/BookService.java
+++ b/src/main/java/com/selman/bookstore/service/BookService.java
@@ -3,8 +3,10 @@ package com.selman.bookstore.service;
 
 import com.selman.bookstore.domain.Book;
 import com.selman.bookstore.repository.BookRepository;
+import com.selman.bookstore.repository.specification.BookSpecification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,15 +16,20 @@ import java.util.Optional;
 public class BookService {
 
     private final BookRepository bookRepository;
+    private final BookSpecification bookSpecification;
 
     // Constructor Injection
 
-    public BookService(BookRepository bookRepository) {
+    public BookService(BookRepository bookRepository, BookSpecification bookSpecification) {
         this.bookRepository = bookRepository;
+        this.bookSpecification = bookSpecification;
     }
 
-    public Page<Book> findAllBooks(Pageable pageable) {
-        return bookRepository.findAll(pageable);
+    public Page<Book> findAllBooks(String title, Integer publicationYear, Pageable pageable) {
+        Specification<Book> spec = Specification
+                .where(bookSpecification.hasTitle(title))
+                .and(bookSpecification.hasPublicationYear(publicationYear));
+        return bookRepository.findAll(spec, pageable);
     }
 
     public Optional<Book> findBookById(Long id) {

--- a/src/main/java/com/selman/bookstore/web/rest/BookController.java
+++ b/src/main/java/com/selman/bookstore/web/rest/BookController.java
@@ -38,8 +38,11 @@ public class BookController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<BookDTO>> getAllBooks(Pageable pageable) {
-        Page<Book> bookPage = bookService.findAllBooks(pageable);
+    public ResponseEntity<Page<BookDTO>> getAllBooks(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) Integer publicationYear,
+            Pageable pageable) {
+        Page<Book> bookPage = bookService.findAllBooks(title, publicationYear, pageable);
         Page<BookDTO> bookDTOPage = bookPage.map(bookMapper::toDTO);
         return ResponseEntity.ok(bookDTOPage);
     }


### PR DESCRIPTION
## Description
This PR enhances the `GET /api/books` endpoint by adding dynamic filtering capabilities using the JPA Specification API. Users can now filter the book list by `title` and/or `publicationYear`.

### Changes
- Created `BookSpecification` to build dynamic query predicates.
- Updated `BookRepository` to extend `JpaSpecificationExecutor`.
- Modified `BookService` and `BookController` to accept and process filter parameters.

## Related Issue
Closes #12